### PR TITLE
Update awsdevhour-stack.ts

### DIFF
--- a/lib/awsdevhour-stack.ts
+++ b/lib/awsdevhour-stack.ts
@@ -16,7 +16,8 @@ export class AwsdevhourStack extends cdk.Stack {
     // Image Bucket
     // =====================================================================================
     const imageBucket = new s3.Bucket(this, imageBucketName, {
-      removalPolicy: cdk.RemovalPolicy.DESTROY
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
     });
     new cdk.CfnOutput(this, 'imageBucket', { value: imageBucket.bucketName });
 


### PR DESCRIPTION
If we add a image using the `aws s3` cli, and run `cdk destroy` it will not delete as the `s3` is not empty. Adding the line, it will delete the bucket.